### PR TITLE
Add debug logging to example site and SDK tool.

### DIFF
--- a/example_site/package.json
+++ b/example_site/package.json
@@ -42,7 +42,7 @@
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.8.1",
-    "@waymark/waymark-sdk": "^2.3.0",
+    "@waymark/waymark-sdk": "^2.4.0",
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
     "faker": "^5.4.0",

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -111,6 +111,7 @@ export default function ConfigurationControls({ isOpen }) {
       },
       environment,
       timeout: 5000,
+      isDebug: true,
     };
 
     console.log("options", waymarkOptions);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@testing-library/jest-dom": "^5.11.8",
     "@testing-library/react": "^11.2.3",
     "@testing-library/user-event": "^12.6.0",
-    "@waymark/waymark-sdk": "^2.3.0",
+    "@waymark/waymark-sdk": "^2.4.0",
     "axios": "^0.21.1",
     "classnames": "^2.2.6",
     "faker": "^5.4.0",

--- a/src/components/WaymarkInstanceInitializationControls.js
+++ b/src/components/WaymarkInstanceInitializationControls.js
@@ -18,12 +18,12 @@ const DEFAULT_OPTIONS = {
 };
 
 const ENVIRONMENTS = {
-  'harness': 'harness',
-  'local': 'local',
-  'demo': 'demo',
-  'prod': 'prod',
-  'custom': 'custom',
-}
+  harness: "harness",
+  local: "local",
+  demo: "demo",
+  prod: "prod",
+  custom: "custom",
+};
 
 /**
  * Form provides controls to configure and create a new Waymark instance
@@ -49,8 +49,8 @@ export default function WaymarkInstanceInitializationControls({
         }
 
         const formElement = event.target;
-        const partnerID = formElement.partnerID.value;          
-        
+        const partnerID = formElement.partnerID.value;
+
         // Construct options with either a preset env slug or a custom environment host object.
         const waymarkOptions = {
           ...options,
@@ -58,10 +58,11 @@ export default function WaymarkInstanceInitializationControls({
             environment === ENVIRONMENTS.custom
               ? { host: formElement.overrideHost.value }
               : environment,
-        }; 
+          isDebug: true,
+        };
 
         const domElement = document.querySelector(waymarkOptions.domElement);
-        
+
         let waymarkObject;
         // Create a new Waymark instance with our config
         if (environment === ENVIRONMENTS.harness) {
@@ -89,7 +90,9 @@ export default function WaymarkInstanceInitializationControls({
 
       <nav className="navbar">
         <ul>
-          <li><a href="#">Test Site</a></li>
+          <li>
+            <a href="#">Test Site</a>
+          </li>
         </ul>
       </nav>
 


### PR DESCRIPTION
Enables `isDebug` logging for both the tool and the example site.