### PR TITLE
Fix: Ensure package and package-lock files are synced with latest SDK version

### DIFF
--- a/example_site/package-lock.json
+++ b/example_site/package-lock.json
@@ -2627,9 +2627,9 @@
       }
     },
     "@waymark/waymark-sdk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@waymark/waymark-sdk/-/waymark-sdk-2.3.0.tgz",
-      "integrity": "sha512-/HUw2byW+RVEY0r/R1lt4vSShbD5U3vNO+gljyNxHuoDKpoMfcVHfCp71CVaS4rBcVplyu0QdDxakSHVV6r2kQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@waymark/waymark-sdk/-/waymark-sdk-2.4.0.tgz",
+      "integrity": "sha512-4YGCbS4/RNMBd3N8Y9C07Xed0T0tqQINQTl5vNJnrWeJFN1azDRmYb59OxMGRUPTvynQrHCeCc40qzk5ZL59gQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "ajv": "^7.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2746,9 +2746,9 @@
       }
     },
     "@waymark/waymark-sdk": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@waymark/waymark-sdk/-/waymark-sdk-2.3.0.tgz",
-      "integrity": "sha512-/HUw2byW+RVEY0r/R1lt4vSShbD5U3vNO+gljyNxHuoDKpoMfcVHfCp71CVaS4rBcVplyu0QdDxakSHVV6r2kQ==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@waymark/waymark-sdk/-/waymark-sdk-2.4.0.tgz",
+      "integrity": "sha512-4YGCbS4/RNMBd3N8Y9C07Xed0T0tqQINQTl5vNJnrWeJFN1azDRmYb59OxMGRUPTvynQrHCeCc40qzk5ZL59gQ==",
       "requires": {
         "@babel/runtime": "^7.12.5",
         "ajv": "^7.0.3",


### PR DESCRIPTION
CircleCI tests were failing for the SDK because the package-lock files in this repo got de-synced somehow. This ensures they're synced again with the latest version of the SDK