### PR TITLE
Update: Collapse Modal Sections When Modal is Disabled

### DIFF
--- a/example_site/src/components/ConfigurationControls.css
+++ b/example_site/src/components/ConfigurationControls.css
@@ -20,41 +20,6 @@ button.configuration-submit-button {
   margin-left: 16px;
 }
 
-/* Fade In/Out */
-.fade-in {
-  animation: fadeIn linear 1s;
-  -webkit-animation: fadeIn linear 1s;
-  -moz-animation: fadeIn linear 1s;
-  -o-animation: fadeIn linear 1s;
-  -ms-animation: fadeIn linear 1s;
-}
- 
-@keyframes fadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
-}
- 
-@-moz-keyframes fadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
-}
- 
-@-webkit-keyframes fadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
-}
- 
-@-o-keyframes fadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
-}
- 
-@-ms-keyframes fadeIn {
-  0% {opacity:0;}
-  100% {opacity:1;}
-}
-
-
 /* Toggle Switch */
 
 /* The switch - the box around the slider */

--- a/example_site/src/components/ConfigurationControls.css
+++ b/example_site/src/components/ConfigurationControls.css
@@ -20,6 +20,41 @@ button.configuration-submit-button {
   margin-left: 16px;
 }
 
+/* Fade In/Out */
+.fade-in {
+  animation: fadeIn linear 1s;
+  -webkit-animation: fadeIn linear 1s;
+  -moz-animation: fadeIn linear 1s;
+  -o-animation: fadeIn linear 1s;
+  -ms-animation: fadeIn linear 1s;
+}
+ 
+@keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+ 
+@-moz-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+ 
+@-webkit-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+ 
+@-o-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+ 
+@-ms-keyframes fadeIn {
+  0% {opacity:0;}
+  100% {opacity:1;}
+}
+
+
 /* Toggle Switch */
 
 /* The switch - the box around the slider */

--- a/example_site/src/components/ConfigurationControls.css
+++ b/example_site/src/components/ConfigurationControls.css
@@ -20,6 +20,11 @@ button.configuration-submit-button {
   margin-left: 16px;
 }
 
+/* Fade In/Out */
+.modal-fade{
+  transition: opacity 0.3s;
+}
+
 /* Toggle Switch */
 
 /* The switch - the box around the slider */

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -238,8 +238,7 @@ export default function ConfigurationControls({ isOpen }) {
           defaultValue=""
           ref={register}
         />
-      </div>
-      <div>
+
         <h2>Labels</h2>
         <label
           className="form-label configuration-column-3"
@@ -261,6 +260,7 @@ export default function ConfigurationControls({ isOpen }) {
         >
           Purchase Video Label
         </label>
+
         <input
           type="text"
           className="form-input"
@@ -268,7 +268,10 @@ export default function ConfigurationControls({ isOpen }) {
           defaultValue="Buy"
           ref={register}
         />
+      </div>
 
+      <div>
+        <h2>Modals</h2>
         <div className="configuration-controls-subsection">
           <h3>Unsaved Changes Confirmation Modal</h3>
 
@@ -347,7 +350,12 @@ export default function ConfigurationControls({ isOpen }) {
           }
 
         </div>
-
+      </div>
+      
+      <div>
+        <h1></h1>
+        <h2></h2>
+        <br></br>
         <div className="configuration-controls-subsection">
           <h3>Complete Video Confirmation Modal</h3>
 

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -49,132 +49,6 @@ export default function ConfigurationControls({ isOpen }) {
     shouldShowConfirmCompleteVideoModal,
   } = watchFields;
 
-  function renderUnsavedChanges() {
-    return(
-      <div>
-        <label
-              className="form-label configuration-column-3"
-              htmlFor="unsavedChangesModalTitle"
-            >
-              Modal Title
-        </label>
-        
-        <input
-              type="text"
-              className="form-input"
-              name="unsavedChangesModalTitle"
-              defaultValue="Exit Editor"
-              ref={register}
-        />
-        
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="unsavedChangesModalBody"
-        >
-          Modal Body Text
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="unsavedChangesModalBody"
-          defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
-          ref={register}
-        />
-
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="unsavedChangesModalConfirmButton"
-        >
-          Modal Confirmation Button Label
-        </label>  
-        <input
-          type="text"
-          className="form-input"
-          name="unsavedChangesModalConfirmButton"
-          defaultValue="Exit Editor"
-          ref={register}
-        />
-
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="unsavedChangesModalCancelButton"
-        >
-          Modal Cancel Button Label
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="unsavedChangesModalCancelButton"
-          defaultValue="Cancel"
-          ref={register}
-        />
-      </div>
-    );
-  }
-
-  function renderCompleteVideo() {
-    return(
-      <div class>
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="confirmCompleteVideoModalTitle"
-        >
-          Modal Title
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="confirmCompleteVideoModalTitle"
-          defaultValue="Finalize Video"
-          ref={register}
-        />
-
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="confirmCompleteVideoModalBody"
-        >
-          Modal Body Text
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="confirmCompleteVideoModalBody"
-          defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
-          ref={register}
-        />
-
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="confirmCompleteVideoModalConfirmButton"
-        >
-          Modal Confirmation Button Label
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="confirmCompleteVideoModalConfirmButton"
-          defaultValue="Confirm"
-          ref={register}
-        />
-
-        <label
-          className="form-label configuration-column-3"
-          htmlFor="confirmCompleteVideoModalCancelButton"
-        >
-          Modal Cancel Button Label
-        </label>
-        <input
-          type="text"
-          className="form-input"
-          name="confirmCompleteVideoModalCancelButton"
-          defaultValue="Cancel"
-          ref={register}
-        />
-      </div>
-    );
-  }
-  //testing area
-
   const onSubmit = async (formData) => {
     const {
       environment,
@@ -410,7 +284,66 @@ export default function ConfigurationControls({ isOpen }) {
 
           { 
             //Collapse Unsaved Changes Confirmation Modal
-            shouldShowUnsavedChangesModal && renderUnsavedChanges() 
+            shouldShowUnsavedChangesModal ? (
+              <div class="fade-in">
+                <label
+                      className="form-label configuration-column-3"
+                      htmlFor="unsavedChangesModalTitle"
+                    >
+                      Modal Title
+                </label>
+                
+                <input
+                      type="text"
+                      className="form-input"
+                      name="unsavedChangesModalTitle"
+                      defaultValue="Exit Editor"
+                      ref={register}
+                />
+                
+                <label
+                  className="form-label configuration-column-3"
+                  htmlFor="unsavedChangesModalBody"
+                >
+                  Modal Body Text
+                </label>
+                <input
+                  type="text"
+                  className="form-input"
+                  name="unsavedChangesModalBody"
+                  defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
+                  ref={register}
+                />
+
+                <label
+                  className="form-label configuration-column-3"
+                  htmlFor="unsavedChangesModalConfirmButton"
+                >
+                  Modal Confirmation Button Label
+                </label>  
+                <input
+                  type="text"
+                  className="form-input"
+                  name="unsavedChangesModalConfirmButton"
+                  defaultValue="Exit Editor"
+                  ref={register}
+                />
+
+                <label
+                  className="form-label configuration-column-3"
+                  htmlFor="unsavedChangesModalCancelButton"
+                >
+                  Modal Cancel Button Label
+                </label>
+                <input
+                  type="text"
+                  className="form-input"
+                  name="unsavedChangesModalCancelButton"
+                  defaultValue="Cancel"
+                  ref={register}
+                />
+              </div>
+            ) : null
           }
 
         </div>
@@ -433,7 +366,65 @@ export default function ConfigurationControls({ isOpen }) {
 
           { 
             //Collapse Complete Video Confirmation Modal
-            shouldShowConfirmCompleteVideoModal && renderCompleteVideo() 
+            shouldShowConfirmCompleteVideoModal ? (
+            <div class="fade-in">
+              <label
+                className="form-label configuration-column-3"
+                htmlFor="confirmCompleteVideoModalTitle"
+              >
+                Modal Title
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                name="confirmCompleteVideoModalTitle"
+                defaultValue="Finalize Video"
+                ref={register}
+              />
+      
+              <label
+                className="form-label configuration-column-3"
+                htmlFor="confirmCompleteVideoModalBody"
+              >
+                Modal Body Text
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                name="confirmCompleteVideoModalBody"
+                defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
+                ref={register}
+              />
+      
+              <label
+                className="form-label configuration-column-3"
+                htmlFor="confirmCompleteVideoModalConfirmButton"
+              >
+                Modal Confirmation Button Label
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                name="confirmCompleteVideoModalConfirmButton"
+                defaultValue="Confirm"
+                ref={register}
+              />
+      
+              <label
+                className="form-label configuration-column-3"
+                htmlFor="confirmCompleteVideoModalCancelButton"
+              >
+                Modal Cancel Button Label
+              </label>
+              <input
+                type="text"
+                className="form-input"
+                name="confirmCompleteVideoModalCancelButton"
+                defaultValue="Cancel"
+                ref={register}
+              />
+            </div>
+            ) : null
           }
 
         </div>

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -49,6 +49,132 @@ export default function ConfigurationControls({ isOpen }) {
     shouldShowConfirmCompleteVideoModal,
   } = watchFields;
 
+  function renderUnsavedChanges() {
+    return(
+      <div>
+        <label
+              className="form-label configuration-column-3"
+              htmlFor="unsavedChangesModalTitle"
+            >
+              Modal Title
+        </label>
+        
+        <input
+              type="text"
+              className="form-input"
+              name="unsavedChangesModalTitle"
+              defaultValue="Exit Editor"
+              ref={register}
+        />
+        
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="unsavedChangesModalBody"
+        >
+          Modal Body Text
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="unsavedChangesModalBody"
+          defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
+          ref={register}
+        />
+
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="unsavedChangesModalConfirmButton"
+        >
+          Modal Confirmation Button Label
+        </label>  
+        <input
+          type="text"
+          className="form-input"
+          name="unsavedChangesModalConfirmButton"
+          defaultValue="Exit Editor"
+          ref={register}
+        />
+
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="unsavedChangesModalCancelButton"
+        >
+          Modal Cancel Button Label
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="unsavedChangesModalCancelButton"
+          defaultValue="Cancel"
+          ref={register}
+        />
+      </div>
+    );
+  }
+
+  function renderCompleteVideo() {
+    return(
+      <div class>
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="confirmCompleteVideoModalTitle"
+        >
+          Modal Title
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="confirmCompleteVideoModalTitle"
+          defaultValue="Finalize Video"
+          ref={register}
+        />
+
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="confirmCompleteVideoModalBody"
+        >
+          Modal Body Text
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="confirmCompleteVideoModalBody"
+          defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
+          ref={register}
+        />
+
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="confirmCompleteVideoModalConfirmButton"
+        >
+          Modal Confirmation Button Label
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="confirmCompleteVideoModalConfirmButton"
+          defaultValue="Confirm"
+          ref={register}
+        />
+
+        <label
+          className="form-label configuration-column-3"
+          htmlFor="confirmCompleteVideoModalCancelButton"
+        >
+          Modal Cancel Button Label
+        </label>
+        <input
+          type="text"
+          className="form-input"
+          name="confirmCompleteVideoModalCancelButton"
+          defaultValue="Cancel"
+          ref={register}
+        />
+      </div>
+    );
+  }
+  //testing area
+
   const onSubmit = async (formData) => {
     const {
       environment,
@@ -282,61 +408,11 @@ export default function ConfigurationControls({ isOpen }) {
             Show the unsaved changes modal?
           </label>
 
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="unsavedChangesModalTitle"
-          >
-            Modal Title
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="unsavedChangesModalTitle"
-            defaultValue="Exit Editor"
-            ref={register}
-          />
+          { 
+            //Collapse Unsaved Changes Confirmation Modal
+            shouldShowUnsavedChangesModal && renderUnsavedChanges() 
+          }
 
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="unsavedChangesModalBody"
-          >
-            Modal Body Text
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="unsavedChangesModalBody"
-            defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
-            ref={register}
-          />
-
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="unsavedChangesModalConfirmButton"
-          >
-            Modal Confirmation Button Label
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="unsavedChangesModalConfirmButton"
-            defaultValue="Exit Editor"
-            ref={register}
-          />
-
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="unsavedChangesModalCancelButton"
-          >
-            Modal Cancel Button Label
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="unsavedChangesModalCancelButton"
-            defaultValue="Cancel"
-            ref={register}
-          />
         </div>
 
         <div className="configuration-controls-subsection">
@@ -355,61 +431,11 @@ export default function ConfigurationControls({ isOpen }) {
             Show the complete video confirmation modal?
           </label>
 
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="confirmCompleteVideoModalTitle"
-          >
-            Modal Title
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="confirmCompleteVideoModalTitle"
-            defaultValue="Finalize Video"
-            ref={register}
-          />
+          { 
+            //Collapse Complete Video Confirmation Modal
+            shouldShowConfirmCompleteVideoModal && renderCompleteVideo() 
+          }
 
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="confirmCompleteVideoModalBody"
-          >
-            Modal Body Text
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="confirmCompleteVideoModalBody"
-            defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
-            ref={register}
-          />
-
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="confirmCompleteVideoModalConfirmButton"
-          >
-            Modal Confirmation Button Label
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="confirmCompleteVideoModalConfirmButton"
-            defaultValue="Confirm"
-            ref={register}
-          />
-
-          <label
-            className="form-label configuration-column-3"
-            htmlFor="confirmCompleteVideoModalCancelButton"
-          >
-            Modal Cancel Button Label
-          </label>
-          <input
-            type="text"
-            className="form-input"
-            name="confirmCompleteVideoModalCancelButton"
-            defaultValue="Cancel"
-            ref={register}
-          />
         </div>
       </div>
     </form>

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -284,71 +284,73 @@ export default function ConfigurationControls({ isOpen }) {
             />
             Show the unsaved changes modal?
           </label>
-
-          { 
-            //Collapse Unsaved Changes Confirmation Modal
-            shouldShowUnsavedChangesModal ? (
-              <div class="fade-in">
-                <label
-                      className="form-label configuration-column-3"
-                      htmlFor="unsavedChangesModalTitle"
-                    >
-                      Modal Title
-                </label>
-                
-                <input
-                      type="text"
-                      className="form-input"
-                      name="unsavedChangesModalTitle"
-                      defaultValue="Exit Editor"
-                      ref={register}
-                />
-                
-                <label
+           
+          <div 
+            className='modal-fade'
+            style={{
+              opacity: shouldShowUnsavedChangesModal ? 1 : 0
+            }}
+          >
+            <label
                   className="form-label configuration-column-3"
-                  htmlFor="unsavedChangesModalBody"
+                  htmlFor="unsavedChangesModalTitle"
                 >
-                  Modal Body Text
-                </label>
-                <input
+                  Modal Title
+            </label>
+            
+            <input
                   type="text"
                   className="form-input"
-                  name="unsavedChangesModalBody"
-                  defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
-                  ref={register}
-                />
-
-                <label
-                  className="form-label configuration-column-3"
-                  htmlFor="unsavedChangesModalConfirmButton"
-                >
-                  Modal Confirmation Button Label
-                </label>  
-                <input
-                  type="text"
-                  className="form-input"
-                  name="unsavedChangesModalConfirmButton"
+                  name="unsavedChangesModalTitle"
                   defaultValue="Exit Editor"
                   ref={register}
-                />
+            />
+            
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="unsavedChangesModalBody"
+            >
+              Modal Body Text
+            </label>
 
-                <label
-                  className="form-label configuration-column-3"
-                  htmlFor="unsavedChangesModalCancelButton"
-                >
-                  Modal Cancel Button Label
-                </label>
-                <input
-                  type="text"
-                  className="form-input"
-                  name="unsavedChangesModalCancelButton"
-                  defaultValue="Cancel"
-                  ref={register}
-                />
-              </div>
-            ) : null
-          }
+            <input
+              type="text"
+              className="form-input"
+              name="unsavedChangesModalBody"
+              defaultValue="Your video has unsaved edits. Are you sure you want to leave?"
+              ref={register}
+            />
 
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="unsavedChangesModalConfirmButton"
+            >
+              Modal Confirmation Button Label
+            </label>  
+
+            <input
+              type="text"
+              className="form-input"
+              name="unsavedChangesModalConfirmButton"
+              defaultValue="Exit Editor"
+              ref={register}
+            />
+
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="unsavedChangesModalCancelButton"
+            >
+              Modal Cancel Button Label
+            </label>
+
+            <input
+              type="text"
+              className="form-input"
+              name="unsavedChangesModalCancelButton"
+              defaultValue="Cancel"
+              ref={register}
+            />
+          </div>
         </div>
       </div>
       
@@ -372,69 +374,68 @@ export default function ConfigurationControls({ isOpen }) {
             Show the complete video confirmation modal?
           </label>
 
-          { 
-            //Collapse Complete Video Confirmation Modal
-            shouldShowConfirmCompleteVideoModal ? (
-            <div class="fade-in">
-              <label
-                className="form-label configuration-column-3"
-                htmlFor="confirmCompleteVideoModalTitle"
-              >
-                Modal Title
-              </label>
-              <input
-                type="text"
-                className="form-input"
-                name="confirmCompleteVideoModalTitle"
-                defaultValue="Finalize Video"
-                ref={register}
-              />
-      
-              <label
-                className="form-label configuration-column-3"
-                htmlFor="confirmCompleteVideoModalBody"
-              >
-                Modal Body Text
-              </label>
-              <input
-                type="text"
-                className="form-input"
-                name="confirmCompleteVideoModalBody"
-                defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
-                ref={register}
-              />
-      
-              <label
-                className="form-label configuration-column-3"
-                htmlFor="confirmCompleteVideoModalConfirmButton"
-              >
-                Modal Confirmation Button Label
-              </label>
-              <input
-                type="text"
-                className="form-input"
-                name="confirmCompleteVideoModalConfirmButton"
-                defaultValue="Confirm"
-                ref={register}
-              />
-      
-              <label
-                className="form-label configuration-column-3"
-                htmlFor="confirmCompleteVideoModalCancelButton"
-              >
-                Modal Cancel Button Label
-              </label>
-              <input
-                type="text"
-                className="form-input"
-                name="confirmCompleteVideoModalCancelButton"
-                defaultValue="Cancel"
-                ref={register}
-              />
-            </div>
-            ) : null
-          }
-
+          <div 
+            className='modal-fade'
+            style={{
+              opacity: shouldShowConfirmCompleteVideoModal ? 1 : 0
+            }}
+          >
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="confirmCompleteVideoModalTitle"
+            >
+              Modal Title
+            </label>
+            <input
+              type="text"
+              className="form-input"
+              name="confirmCompleteVideoModalTitle"
+              defaultValue="Finalize Video"
+              ref={register}
+            />
+    
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="confirmCompleteVideoModalBody"
+            >
+              Modal Body Text
+            </label>
+            <input
+              type="text"
+              className="form-input"
+              name="confirmCompleteVideoModalBody"
+              defaultValue="By finalizing this video, you confirm that you own the rights to all of its content."
+              ref={register}
+            />
+    
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="confirmCompleteVideoModalConfirmButton"
+            >
+              Modal Confirmation Button Label
+            </label>
+            <input
+              type="text"
+              className="form-input"
+              name="confirmCompleteVideoModalConfirmButton"
+              defaultValue="Confirm"
+              ref={register}
+            />
+    
+            <label
+              className="form-label configuration-column-3"
+              htmlFor="confirmCompleteVideoModalCancelButton"
+            >
+              Modal Cancel Button Label
+            </label>
+            <input
+              type="text"
+              className="form-input"
+              name="confirmCompleteVideoModalCancelButton"
+              defaultValue="Cancel"
+              ref={register}
+            />
+          </div>
         </div>
       </div>
     </form>


### PR DESCRIPTION
https://app.clickup.com/t/xq9a7r

Updated initial SDK screen so that when either the “Unsaved Changes Confirmation Modal” or “Complete Video Confirmation Modal” are unchecked, the corresponding form fields are hidden. 