### PR TITLE
Update: Collapse Modal Sections When Modal is Disabled

### DIFF
--- a/example_site/src/components/ConfigurationControls.css
+++ b/example_site/src/components/ConfigurationControls.css
@@ -25,6 +25,10 @@ button.configuration-submit-button {
   transition: opacity 0.3s;
 }
 
+.top-padding {
+  padding-top: 45px;
+}
+
 /* Toggle Switch */
 
 /* The switch - the box around the slider */

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -355,10 +355,7 @@ export default function ConfigurationControls({ isOpen }) {
       </div>
       
       <div>
-        <h1></h1>
-        <h2></h2>
-        <br></br>
-        <div className="configuration-controls-subsection">
+        <div className="top-padding configuration-controls-subsection">
           <h3>Complete Video Confirmation Modal</h3>
 
           <label


### PR DESCRIPTION
https://app.clickup.com/t/xq9a7r

Used top padding (CSS) instead of HTML (br and h3 spacing) to align the Complete Video Confirmation Modal vertically with the Unsaved Changes Confirmation Modal.