### PR TITLE
Update: Demo Site Dynamic Flows

### DIFF
--- a/example_site/package-lock.json
+++ b/example_site/package-lock.json
@@ -13068,15 +13068,6 @@
         }
       }
     },
-    "react-simple-snackbar": {
-      "version": "1.1.10",
-      "resolved": "https://registry.npmjs.org/react-simple-snackbar/-/react-simple-snackbar-1.1.10.tgz",
-      "integrity": "sha512-doN5IULuUwJraNVwgMICjzueODYgOvI1GhoSw7W4gmyF6KUXp+uv7KnpFv8oEyz4tr0XBmpdO/AK1/M1PmJmUg==",
-      "requires": {
-        "@babel/runtime": "^7.7.6",
-        "react-transition-group": "^4.3.0"
-      }
-    },
     "react-tooltip": {
       "version": "4.2.15",
       "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-4.2.15.tgz",

--- a/example_site/package.json
+++ b/example_site/package.json
@@ -60,7 +60,6 @@
     "react-query": "^3.12.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.1",
-    "react-simple-snackbar": "^1.1.10",
     "react-tooltip": "^4.2.15",
     "stats.js": "^0.17.0",
     "uuid": "^8.3.2"

--- a/example_site/src/components/AccountInfoForm.js
+++ b/example_site/src/components/AccountInfoForm.js
@@ -12,7 +12,6 @@ export default function AccountInfoForm({
   submitButtonText,
   requireInputChange,
 }) {
-  const { openSnackbar } = useAppContext();
   const { register, handleSubmit, watch } = useForm();
   const [isButtonDisabled, setIsButtonDisabled] = useState(requireInputChange);
   const watchFields = watch();
@@ -35,12 +34,6 @@ export default function AccountInfoForm({
 
   const onFormSubmitError = (errors) => {
     console.log("Error submitting form: ", errors);
-
-    openSnackbar(
-      `Please fix the following errors:\n${Object.values(errors)
-        .map((error) => error.message)
-        .join("\n")}`
-    );
   };
 
   return (

--- a/example_site/src/components/AccountInfoForm.js
+++ b/example_site/src/components/AccountInfoForm.js
@@ -2,8 +2,6 @@ import { useForm } from "react-hook-form";
 import React, { useEffect, useState } from "react";
 import _ from 'lodash';
 
-import { useAppContext } from "./AppProvider";
-
 export default function AccountInfoForm({
   account,
   onFormSubmit,

--- a/example_site/src/components/AccountPage.js
+++ b/example_site/src/components/AccountPage.js
@@ -13,7 +13,6 @@ export default function AccountPage() {
     onResetWaymarkInstance,
     account,
     setAccount,
-    openSnackbar,
   } = useAppContext();
 
   // Commented out code because getVideos is not implemented yet
@@ -31,12 +30,10 @@ export default function AccountPage() {
       const account = await waymarkInstance.updateAccountInfo(formData);
 
       console.log("Account successfully updated ", account);
-      openSnackbar("Account successfully updated");
 
       setAccount(account);
     } catch (error) {
       console.error("updateAccountInfo error", error);
-      openSnackbar(error.message);
     }
   };
 
@@ -65,7 +62,8 @@ export default function AccountPage() {
 
       <button 
         className="submit-button configuration-submit-button"
-        onClick={onResetWaymarkInstance}>
+        onClick={onResetWaymarkInstance}
+      >
         Back To Start
       </button>
 

--- a/example_site/src/components/AccountPage.js
+++ b/example_site/src/components/AccountPage.js
@@ -62,7 +62,7 @@ export default function AccountPage() {
 
       <button 
         className="submit-button configuration-submit-button"
-        onClick={onResetWaymarkInstance}
+        onClick={async () => await onResetWaymarkInstance()}
       >
         Back To Start
       </button>

--- a/example_site/src/components/AdPortalLanding.js
+++ b/example_site/src/components/AdPortalLanding.js
@@ -1,6 +1,5 @@
 import Header from "./Header.js";
 import { useHistory } from "react-router-dom";
-import { adPortalConfiguration } from "../constants/app";
 import { useAppContext } from "./AppProvider";
 
 function SelectTemplateButton() {

--- a/example_site/src/components/AdPortalLanding.js
+++ b/example_site/src/components/AdPortalLanding.js
@@ -1,19 +1,52 @@
 import Header from "./Header.js";
+import { useHistory } from "react-router-dom";
+import { adPortalConfiguration } from "../constants/app";
+import { useAppContext } from "./AppProvider";
+
+function SelectTemplateButton() {
+    const {
+        waymarkInstance,
+        setAccount,
+        partnerID,
+        partnerSecret,
+        getSignedJWT,
+    } = useAppContext();
+
+    const history = useHistory();
+
+    function onSubmit() {
+        const signedJWT = getSignedJWT({}, partnerID, partnerSecret);
+    
+        waymarkInstance.createAccount(signedJWT);
+    
+        history.push("/templates");
+    
+        const account = waymarkInstance.getAccountInfo();
+        setAccount(account);
+    };
+
+    return (
+        <button 
+            className="submit-button"
+            onClick={() => onSubmit()}
+        >
+            Select Your Template
+        </button>
+    );
+}
 
 /**
  * Landing Page in Ad Portal Workflow
  */
 export default function AdPortalLanding() {
-  return (
-    <div className='center'>
-        <Header 
-            title="Welcome to the ABC Ad Portal"
-            subtitle="Now that your audience is set, it’s 
-            time to make a commercial for your campaign."
-        />
-        <button className="submit-button">
-            Select Your Template
-        </button>
-    </div>
-  );
+    return (
+        <div className='center'>
+            <Header 
+                title="Welcome to the ABC Ad Portal"
+                subtitle="Now that your audience is set, it’s 
+                time to make a commercial for your campaign."
+            />
+            <SelectTemplateButton />
+        </div>
+    );
 }

--- a/example_site/src/components/App.js
+++ b/example_site/src/components/App.js
@@ -2,13 +2,8 @@ import React, { useEffect } from "react";
 import "jsoneditor-react/es/editor.min.css";
 import { Route } from "react-router-dom";
 
-import AccountAuthentication from "./AccountAuthentication";
-import AccountPage from "./AccountPage";
 import TemplateBrowser from "./TemplateBrowser";
 import ConfigurationControls from "./ConfigurationControls";
-import PurchaseVideo from "./PurchaseVideo";
-import AdPortalLanding from "./AdPortalLanding";
-import AdPortalConfirmation from "./AdPortalConfirmation";
 import { useAppContext } from "./AppProvider";
 import "./App.css";
 import Editor from "./Editor.js";
@@ -20,6 +15,8 @@ function App() {
     isEditorOpen,
     purchaseVideo,
     waymarkInstance,
+    siteConfiguration,
+    setEditorNextURL,
   } = useAppContext();
 
   useEffect(() => {
@@ -34,6 +31,8 @@ function App() {
       console.log("editorOpenFailed", event);
     });
     waymarkInstance.on("editorExited", (event) => {
+      // Temporary solution to redirecting to correct page after editor
+      setEditorNextURL("/");
       console.log("editorExited", event);
       closeEditor();
     });
@@ -45,30 +44,27 @@ function App() {
       console.log("videoRendered", event);
     });
   }, [waymarkInstance, closeEditor, purchaseVideo]);
+
+  const getRootPathComponent = () => {
+    if (!waymarkInstance) return (<ConfigurationControls />);
+
+    const PostConfigurationComponent = siteConfiguration.navigations.postConfiguration;
+    if (!account) return (<PostConfigurationComponent />);
+
+    const PostEditorComponent = siteConfiguration.navigations.postEditor;
+    return (<PostEditorComponent />);
+  }
  
   return (
     <main>
-      <ConfigurationControls />
+      <Route exact path="/">
+        {getRootPathComponent()}
+      </Route>
 
       <Editor />
 
-      <Route path="/editor">{ !isEditorOpen && "Editor is closed."}</Route>
-      <Route path="/collections">
+      <Route path="/templates">
         <TemplateBrowser waymarkInstance={waymarkInstance} />
-      </Route>
-
-      <Route exact path="/">
-        <div>
-          {account ? (
-            <AccountPage />
-          ) : (
-            waymarkInstance && <AccountAuthentication />
-          )}
-        </div>
-      </Route>
-
-      <Route path="/purchase">
-        <PurchaseVideo />
       </Route>
     </main>
   );

--- a/example_site/src/components/App.js
+++ b/example_site/src/components/App.js
@@ -12,7 +12,6 @@ function App() {
   const {
     account,
     closeEditor,
-    isEditorOpen,
     purchaseVideo,
     waymarkInstance,
     siteConfiguration,
@@ -43,7 +42,7 @@ function App() {
     waymarkInstance.on("videoRendered", (event) => {
       console.log("videoRendered", event);
     });
-  }, [waymarkInstance, closeEditor, purchaseVideo]);
+  }, [waymarkInstance, closeEditor, purchaseVideo, setEditorNextURL]);
 
   const getRootPathComponent = () => {
     if (!waymarkInstance) return (<ConfigurationControls />);

--- a/example_site/src/components/AppProvider.js
+++ b/example_site/src/components/AppProvider.js
@@ -1,34 +1,30 @@
 import _ from "lodash";
 import React, { useCallback, useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
-import { useSnackbar } from "react-simple-snackbar";
 
-import { blueColor } from "../constants/app";
+import KJUR from "jsrsasign";
+import faker from "faker";
 
 const AppContext = React.createContext({
   account: false,
   setAccount: () => {},
-  addTemplates: () => {},
   closeEditor: () => {},
   purchaseVideo: () => {},
   embedRef: null,
   isEditorOpen: false,
   openEditor: () => {},
-  openSnackbar: () => {},
   partnerID: "test-partner",
   setPartnerID: () => {},
   partnerSecret: "zubbythewonderllamaeatsrhubarb",
   setPartnerSecret: () => {},
-  editorNextURL: "/collections",
+  editorNextURL: "/templates",
   setEditorNextURL: () => {},
-  showLandingPage: true,
-  setShowLandingPage: () => {},
-  templates: {},
-  useSnackbar: () => {},
   waymarkInstance: null,
   setWaymarkInstance: () => {},
   showCustomForm: false,
   setShowCustomForm: () => {},
+  siteConfiguration: {},
+  setSiteConfiguration: () => {},
 });
 
 export const useAppContext = () => useContext(AppContext);
@@ -36,25 +32,15 @@ export const useAppContext = () => useContext(AppContext);
 export const AppProvider = ({ children }) => {
   const [waymarkInstance, setWaymarkInstance] = useState(null);
   const [account, setAccount] = useState(null);
-  const [templates, setTemplates] = useState({});
   const [isEditorOpen, setIsEditorOpen] = useState(false);
   const [partnerID, setPartnerID] = useState("fake-partner-id");
   const [partnerSecret, setPartnerSecret] = useState("zubbythewonderllamaeatsrhubarb");
-  const [editorNextURL, setEditorNextURL] = useState("/collections");
-  const [showLandingPage, setShowLandingPage] = useState(true);
+  const [editorNextURL, setEditorNextURL] = useState("/templates");
   const [showCustomForm, setShowCustomForm] = useState(false);
+  const [siteConfiguration, setSiteConfiguration] = useState({});
+
   const history = useHistory();
   const embedRef = React.useRef(null);
-
-  const [openSnackbar] = useSnackbar({
-    style: {
-      backgroundColor: blueColor,
-      textColor: "white",
-      fontWeight: "bold",
-      fontSize: "16px",
-      whiteSpace: "pre-wrap",
-    },
-  });
 
   const openEditor = useCallback(
     ({ template }) => {
@@ -77,61 +63,63 @@ export const AppProvider = ({ children }) => {
       setIsEditorOpen(false);
     }, [setIsEditorOpen, setEditorNextURL]);
 
-  const addTemplates = useCallback(
-    (newTemplates) => {
-      if (_.isEmpty(newTemplates)) return;
-
-      const allTemplates = { ...templates };
-      newTemplates.forEach((template) => {
-        allTemplates[template.id] = template;
-      });
-      setTemplates(allTemplates);
-    },
-    [setTemplates, templates]
-  );
-
-  const getTemplateByID = (templateID) => {
-    return templates[templateID];
-  };
-
   const goHome = () => {
     console.log("HOME");
     setIsEditorOpen(false);
     history.push("/");
   };
 
+  const getSignedJWT = (accountData, partnerID, partnerSecret) => {
+    // Header
+    const header = { alg: "HS256", typ: "JWT" };
+    // Payload
+    const payload = {
+      jti: faker.random.uuid(),
+      iss: partnerID,
+      aud: "waymark.com",
+      iat: KJUR.jws.IntDate.get("now"),
+      exp: KJUR.jws.IntDate.get("now + 1hour"),
+      "https://waymark.com/sdk/account": accountData,
+    };
+  
+    // Sign JWT with our secret
+    return KJUR.jws.JWS.sign(
+      "HS256",
+      JSON.stringify(header),
+      JSON.stringify(payload),
+      partnerSecret
+    );
+  };
+
   async function onResetWaymarkInstance() {
     await waymarkInstance.cleanup();
     setWaymarkInstance(null);
     setAccount(null);
-    setEditorNextURL('/collections');
-    setShowLandingPage(true);
+    setEditorNextURL('/templates');
     setShowCustomForm(false);
 }
 
   const value = {
     account,
     setAccount,
-    addTemplates,
     closeEditor,
     purchaseVideo, 
     embedRef,
-    getTemplateByID,
     goHome,
+    getSignedJWT,
     onResetWaymarkInstance,
     isEditorOpen,
     openEditor,
-    openSnackbar,
     partnerID,
     setPartnerID,
     partnerSecret,
     setPartnerSecret,
     editorNextURL,
     setEditorNextURL,
-    showLandingPage,
-    setShowLandingPage,
     showCustomForm,
     setShowCustomForm,
+    siteConfiguration,
+    setSiteConfiguration,
     waymarkInstance,
     setWaymarkInstance,
   };

--- a/example_site/src/components/AppProvider.js
+++ b/example_site/src/components/AppProvider.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import React, { useCallback, useContext, useState } from "react";
 import { useHistory } from "react-router-dom";
 

--- a/example_site/src/components/ConfigurationControls.css
+++ b/example_site/src/components/ConfigurationControls.css
@@ -1,14 +1,3 @@
-.title-description {
-  display: grid;
-  place-items: start;
-  grid-auto-flow: row;
-}
-
-.title-description.closed {
-  height: 0;
-  display: none;
-}
-
 .configuration-controls-form {
   display: grid;
   place-items: start;

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -152,7 +152,7 @@ export default function ConfigurationControls() {
       setWaymarkInstance(newWaymarkInstance);
       console.log(newWaymarkInstance);
     } catch (error) {
-      console.error(error);
+      console.error(`Problem initializing SDK: ${error}`);
     }
   };
 

--- a/example_site/src/components/ConfigurationControls.js
+++ b/example_site/src/components/ConfigurationControls.js
@@ -1,5 +1,4 @@
 import { useForm } from "react-hook-form";
-import classnames from "classnames";
 
 import Waymark from "@waymark/waymark-sdk";
 
@@ -7,7 +6,7 @@ import { useAppContext } from "./AppProvider";
 import "./ConfigurationControls.css";
 import Header from "./Header.js";
 
-import { partnerConfigurations } from "../constants/app";
+import { siteConfigurations } from "../constants/app";
 
 /**
  * Configuration for the entire application.
@@ -22,13 +21,11 @@ export default function ConfigurationControls() {
     setPartnerID,
     partnerSecret: defaultPartnerSecret,
     setPartnerSecret,
-    showLandingPage,
-    setShowLandingPage,
     showCustomForm,
     setShowCustomForm,
+    setSiteConfiguration,
     waymarkInstance,
     setWaymarkInstance,
-    openSnackbar,
   } = useAppContext();
 
   const watchFields = watch(
@@ -70,15 +67,16 @@ export default function ConfigurationControls() {
   }
 
   function clickButton (selectSiteConfiguration) {
+    setSiteConfiguration(selectSiteConfiguration);
     if (selectSiteConfiguration.id === 'custom') {
       setShowCustomForm(!showCustomForm);
       return;
     }
-    onSelectConfiguration(selectSiteConfiguration.configuration);   
+    onSelectConfiguration(selectSiteConfiguration.sdkOptions);   
   }
 
   const onSelectConfiguration = async (configuration) => {
-    setShowLandingPage(false);
+
     const {
       environment,
       orientation,
@@ -154,19 +152,12 @@ export default function ConfigurationControls() {
       setWaymarkInstance(newWaymarkInstance);
       console.log(newWaymarkInstance);
     } catch (error) {
-      openSnackbar(`Problem initializing SDK: ${error}`);
+      console.error(error);
     }
   };
 
-  const titlePanel = classnames({
-    "title-description": true,
-     panel: true,
-     open: showLandingPage,
-     closed: !showLandingPage,
-  });
-
   return (
-    <div className={titlePanel}>
+    <div className="title-description">
       <div className='center'>
         <Header 
           title="Welcome to the Waymark SDK"
@@ -180,7 +171,7 @@ export default function ConfigurationControls() {
       </div>
 
       <div className='three-columns'>
-        {partnerConfigurations.map((config) => (
+        {siteConfigurations.map((config) => (
           <div className='configuration-controls-subsection' key={config.id}>
             <button
               className='configuration-card'

--- a/example_site/src/components/PurchaseVideo.js
+++ b/example_site/src/components/PurchaseVideo.js
@@ -5,16 +5,11 @@ export default function PurchaseVideo() {
   const {
     purchasedVideo,
     goHome,
-    getTemplateByID,
-    openSnackbar,
   } = useAppContext();
 
-  const template = purchasedVideo
-    ? getTemplateByID(purchasedVideo.templateID)
-    : {};
+  const template = purchasedVideo;
 
   const completePurchase = () => {
-    openSnackbar("Purchased!");
     setTimeout(goHome, 5000);
   };
 

--- a/example_site/src/components/TemplateBrowser.js
+++ b/example_site/src/components/TemplateBrowser.js
@@ -14,7 +14,11 @@ function Template({ template }) {
 
   return (
     <>
-      <button className="template-button" title={template.id} onClick={() => openEditor({ template })}>
+      <button 
+        className="template-button" 
+        title={template.id} 
+        onClick={() => { openEditor({ template }) }}
+      >
         <div className='template-container'>
           <HoverVideoPlayer
             style={{

--- a/example_site/src/components/TemplateBrowser.js
+++ b/example_site/src/components/TemplateBrowser.js
@@ -1,4 +1,3 @@
-import _ from "lodash";
 import { useEffect, useState } from "react";
 import { useQuery } from "react-query";
 import "jsoneditor-react/es/editor.min.css";

--- a/example_site/src/constants/app.js
+++ b/example_site/src/constants/app.js
@@ -1,3 +1,8 @@
+import AccountAuthentication from "../components/AccountAuthentication";
+import AccountPage from "../components/AccountPage";
+import AdPortalConfirmation from "../components/AdPortalConfirmation";
+import AdPortalLanding from "../components/AdPortalLanding";
+
 export const blueColor = "#005AFF";
 export const blackColor = "#000000";
 
@@ -47,23 +52,35 @@ export const adPortalConfiguration = {
     "editorBackgroundColor": '#FFFFFF',
 };
 
-export const partnerConfigurations = [
+export const siteConfigurations = [
     {
         displayName: 'Generic',
         id: 'generic',
-        configuration: genericConfiguration,
+        sdkOptions: genericConfiguration,
         thumbnailURL: "https://socialproof-prod.imgix.net/video_creatives/videotemplatevariant/thumbnail/1209_1597265598.png?ixlib=react-8.6.4&auto=compress%2Cformat&fit=max&w=512",
+        navigations: {
+            postConfiguration: AccountAuthentication,
+            postEditor: AccountPage,
+        }
     },
     {
         displayName: 'Ad Portal',
         id: 'adPortal',
-        configuration: adPortalConfiguration,
+        sdkOptions: adPortalConfiguration,
         thumbnailURL: "https://socialproof-prod.imgix.net/video_creatives/videotemplatevariant/thumbnail/1209_1597265598.png?ixlib=react-8.6.4&auto=compress%2Cformat&fit=max&w=512",
+        navigations: {
+            postConfiguration: AdPortalLanding,
+            postEditor: AdPortalConfirmation,
+        }
     },
     {
         displayName: 'Custom',
         id: 'custom',
         thumbnailURL: "https://socialproof-prod.imgix.net/video_creatives/videotemplatevariant/thumbnail/1209_1597265598.png?ixlib=react-8.6.4&auto=compress%2Cformat&fit=max&w=512",
+        navigations: {
+            postConfiguration: AccountAuthentication,
+            postEditor: AccountPage,
+        }
     }
 ];
 

--- a/example_site/src/index.js
+++ b/example_site/src/index.js
@@ -2,7 +2,6 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { BrowserRouter } from "react-router-dom";
-import SnackbarProvider from "react-simple-snackbar";
 
 import App from "./components/App";
 import { AppProvider } from "./components/AppProvider";
@@ -20,7 +19,6 @@ const queryClient = new QueryClient({
 
 ReactDOM.render(
   <React.StrictMode>
-    <SnackbarProvider>
       <BrowserRouter>
         <QueryClientProvider client={queryClient}>
           <AppProvider>
@@ -28,7 +26,6 @@ ReactDOM.render(
           </AppProvider>
         </QueryClientProvider>
       </BrowserRouter>
-    </SnackbarProvider>
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
https://app.clickup.com/t/1b8rn81

Changing the flow of the website to work with new Ad Portal configuration. 
- Got rid of showLandingPage logic
- removed PurchaseVideo component and route
- changed /collections route name to /templates 
- removed /editor route in App.js
- removed all snackbars
- added siteConfiguration state value to AppProvider 
- updated partnerConfiguration naming (partnerConfiguration -> siteConfiguration, configuration -> sdkOptions )
- added navigations to siteConfiguration object with redirections for post configuration/editor paths
- siteConfiguration determines that component to render
- for the ad portal flow, when the user clicks the "Select your template" button, account created

Known issues:
When repeatedly going through the ad portal flow, there is always a stopping point which makes the Editor not load. Some of the console errors that appear include: 
TypeError: Cannot read property 'getTemplatesForCollection' of undefined
    at FrameCommunicator.getTemplatesForCollection
TypeError: Cannot read property 'slug' of null
